### PR TITLE
fix(ci): bump deprecated actions, add continue-on-error to npm audit

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -75,7 +75,7 @@ jobs:
         DATABASE_URL: postgresql://postgres:postgres@localhost:5432/test_db
     
     - name: Upload coverage reports
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v5
       with:
         file: ./backend/coverage/lcov.info
         flags: backend
@@ -146,7 +146,7 @@ jobs:
       run: npm run build
     
     - name: Upload build artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: backend-dist
         path: backend/dist/
@@ -174,6 +174,7 @@ jobs:
     - name: Run security audit
       working-directory: ./backend
       run: npm audit --audit-level moderate
+      continue-on-error: true
     
     - name: Run Snyk security scan (if available)
       working-directory: ./backend


### PR DESCRIPTION
## Summary
Fixes #101 — bumps deprecated GitHub Actions and prevents npm audit from blocking unrelated PRs.

## Changes
- Bump `actions/upload-artifact` from v3 → v4
- Bump `codecov/codecov-action` from v3 → v5
- Add `continue-on-error: true` to `npm audit --audit-level moderate` step

## Verification
- All three changes target the exact issues described in #101
- No other deprecated action versions remain in the file
- The workflow structure is preserved
