### PR TITLE
fix(rds): restrict generated DB password to URL-safe characters

### DIFF
--- a/backend/devOps/terraform/modules/ec2/user_data.sh.tpl
+++ b/backend/devOps/terraform/modules/ec2/user_data.sh.tpl
@@ -98,6 +98,10 @@ DB_PASSWORD=$(echo "$DB_SECRET" | jq -r '.password')
 DB_USERNAME=$(echo "$DB_SECRET" | jq -r '.username')
 
 # Application Environment File
+# The DB password is embedded verbatim in DATABASE_URL below. This is safe because
+# random_password.db (modules/rds/main.tf) restricts override_special to the RFC 3986
+# unreserved punctuation (-_.~), so the password never contains URL-reserved characters
+# and the resulting connection URL is always valid without URL-encoding.
 cat > /home/appuser/app/.env << ENV
 NODE_ENV=${environment}
 PORT=${app_port}

--- a/backend/devOps/terraform/modules/rds/main.tf
+++ b/backend/devOps/terraform/modules/rds/main.tf
@@ -13,9 +13,18 @@ locals {
 
 # ─── RANDOM DB PASSWORD ───────────────────────────────────────────────────────
 resource "random_password" "db" {
-  length           = 32
-  special          = true
-  override_special = "!#$%&*()-_=+[]{}<>:?"
+  length  = 32
+  special = true
+
+  # The password is embedded verbatim into a connection URL in the EC2 bootstrap
+  # (see modules/ec2/user_data.sh.tpl):
+  #   DATABASE_URL=postgresql://USER:PASSWORD@host:port/db
+  # Characters reserved in a URL userinfo component (: @ # = + ? % / & and others)
+  # would corrupt the URL and make Prisma/pg misparse host/port/db, so we restrict
+  # the special set to the RFC 3986 "unreserved" punctuation (-_.~). These are safe
+  # unencoded anywhere in a URL, so the generated DATABASE_URL is always valid
+  # without any shell-side URL-encoding.
+  override_special = "-_.~"
 }
 
 # ─── AWS SECRETS MANAGER (stores DB credentials) ──────────────────────────────


### PR DESCRIPTION
## Summary

`modules/ec2/user_data.sh.tpl` composes the app connection string by embedding the master DB password verbatim:

```
DATABASE_URL=postgresql://USER:PASSWORD@endpoint:port/db
```

`random_password.db` in `modules/rds/main.tf` previously set `override_special = "!#$%&*()-_=+[]{}<>:?"`, which includes characters reserved in a URL userinfo component (`: @ # = + ? % / &`). When a generated password contained any of those, the resulting `DATABASE_URL` was malformed and Prisma/pg misparsed host/port/db, so the app could not connect at boot.

This restricts the password's special set to the RFC 3986 *unreserved* punctuation (`-_.~`), which is safe unencoded anywhere in a URL. The composed `DATABASE_URL` is therefore always valid, with no need for fragile shell-side URL-encoding in the template.

## How each acceptance criterion is met

- **Restrict `override_special` to URL-safe characters** — `override_special` is now `"-_.~"` (RFC 3986 unreserved punctuation). `length = 32` and `special = true` are unchanged; there is no `min_special` to keep consistent.
- **A password that previously contained reserved chars now yields a valid `DATABASE_URL`** — the new character universe (`[A-Za-z0-9-_.~]`) contains none of the reserved userinfo characters, so the password never needs encoding and the URL always parses correctly (host/port/db intact). See verification below.
- **Document the chosen approach** — a comment in `modules/rds/main.tf` explains *why* the special set is restricted (URL-safety for `DATABASE_URL`), and a matching note in `modules/ec2/user_data.sh.tpl` records that the verbatim embedding is safe for this reason.

## Verification

`terraform` is not installed in this environment, so `fmt`/`validate` could not be run; changes were formatted and reviewed manually against `terraform fmt` conventions, and the diff is limited to the two issue files.

A standalone parse check confirmed the fix (using Python's `urllib.parse.urlsplit` as a stand-in for a URL parser like pg/Prisma):

- OLD set, password `Ab1=Cd#2:Ef?3+Gh%4&Ij` →
  `postgresql://liquidflow:Ab1=Cd#2:Ef?3+Gh%4&Ij@db.internal:5432/liquidflow`
  → **MALFORMED** (parser reads `Ab1=Cd` as the port and fails).
- NEW set, password `Ab1-Cd_2.Ef~3-Gh_4.Ij~Kl5mNo6pQ` →
  `postgresql://liquidflow:...@db.internal:5432/liquidflow`
  → **VALID** (`hostname=db.internal`, `port=5432`, `path=/liquidflow`).

All four new special chars are RFC 3986 unreserved; the reserved userinfo chars removed from the old set are `# % & = + : ?`.

## Out of scope

Rotating existing credentials and the Secrets Manager schema are intentionally untouched.

Closes #104