### PR TITLE
fix(s3): grant S3 logging service write access to access-logs bucket

### DIFF
--- a/backend/devOps/terraform/modules/s3/main.tf
+++ b/backend/devOps/terraform/modules/s3/main.tf
@@ -53,6 +53,44 @@ resource "aws_s3_bucket_lifecycle_configuration" "access_logs" {
   }
 }
 
+# Bucket policy granting the S3 server-access-logging service write access.
+# With AWS provider 5.x defaulting to BucketOwnerEnforced (ACLs disabled), the
+# legacy log-delivery group ACL no longer works; the logging service principal
+# must be granted s3:PutObject via a bucket policy or access logs silently fail.
+resource "aws_s3_bucket_policy" "access_logs" {
+  bucket = aws_s3_bucket.access_logs.id
+  policy = data.aws_iam_policy_document.access_logs_bucket_policy.json
+
+  depends_on = [aws_s3_bucket_public_access_block.access_logs]
+}
+
+data "aws_iam_policy_document" "access_logs_bucket_policy" {
+  statement {
+    sid       = "AllowS3ServerAccessLogsDelivery"
+    effect    = "Allow"
+    actions   = ["s3:PutObject"]
+    resources = ["${aws_s3_bucket.access_logs.arn}/*"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logging.s3.amazonaws.com"]
+    }
+
+    # Restrict to logging from the source bucket(s) in this account only.
+    condition {
+      test     = "ArnLike"
+      variable = "aws:SourceArn"
+      values   = [aws_s3_bucket.main.arn]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "aws:SourceAccount"
+      values   = [data.aws_caller_identity.current.account_id]
+    }
+  }
+}
+
 # ─── MAIN APPLICATION BUCKET ──────────────────────────────────────────────────
 resource "aws_s3_bucket" "main" {
   bucket        = "${local.name_prefix}-${var.bucket_purpose}-${data.aws_caller_identity.current.account_id}"


### PR DESCRIPTION
## Summary

The `access_logs` bucket in `backend/devOps/terraform/modules/s3/main.tf` is the target of `aws_s3_bucket_logging.main`, but it only had a public-access block and encryption — no bucket policy and no ownership controls. Under AWS provider 5.x, buckets default to `BucketOwnerEnforced` (ACLs disabled), so the legacy log-delivery group ACL no longer works. The server-access-logging service principal must instead be granted `s3:PutObject` via a bucket policy. As written, access logs for the main bucket silently fail to deliver.

This adds an `aws_s3_bucket_policy` (built from an `aws_iam_policy_document`, matching the module's existing style for `main_bucket_policy`) on the `access_logs` bucket.

## How each acceptance criterion is met

- **Bucket policy granting `logging.s3.amazonaws.com` `s3:PutObject` with `aws:SourceArn` / `aws:SourceAccount` conditions** — New `data.aws_iam_policy_document.access_logs_bucket_policy` allows `s3:PutObject` on `${aws_s3_bucket.access_logs.arn}/*` for the `Service` principal `logging.s3.amazonaws.com`, with an `ArnLike` condition on `aws:SourceArn` (the logging source bucket `aws_s3_bucket.main.arn`) and a `StringEquals` condition on `aws:SourceAccount` (`data.aws_caller_identity.current.account_id`). `data.aws_caller_identity.current` already existed in the module, so no new data source was needed.
- **Access logs would actually be delivered after apply** — With the service principal now granted `PutObject` (the modern mechanism required under `BucketOwnerEnforced`), the logging service can write to the access-logs bucket. The policy `depends_on` the public-access block (matching `aws_s3_bucket_policy.main`); the grant is scoped to a specific service principal with source conditions, so it is not a "public" policy and is not rejected by `block_public_policy`.
- **Applied consistently to all server-access-log target buckets** — `access_logs` is the only server-access-log target bucket in the module (only `aws_s3_bucket_logging.main` sets `target_bucket`), and it has a single source bucket, so this one policy covers all targets. The ALB access-log bucket in the `ec2` module already has its own policy and is out of scope.

## Verify

- `terraform` is not installed in this environment, so `fmt` / `validate` could not be run. Reviewed manually: indentation and aligned-equals style match the module's existing `main_bucket_policy` and the ec2 module's `alb_logs_bucket_policy`; brace and bracket counts balance.
- `git diff --stat upstream/main...HEAD`: 1 file changed, 38 insertions(+).

## Out of scope

- ALB access-log delivery (already has its own bucket policy in the `ec2` module).
- Logging retention lifecycle (already configured via `aws_s3_bucket_lifecycle_configuration.access_logs`).

Closes #107