### PR TITLE
fix(infra): resolve AL2023 AMI region-aware via aws_ami data source

### DIFF
--- a/backend/devOps/terraform/environments/dev/terraform.tfvars
+++ b/backend/devOps/terraform/environments/dev/terraform.tfvars
@@ -9,8 +9,10 @@ private_subnet_cidrs = ["10.0.10.0/24", "10.0.20.0/24"]
 availability_zones   = ["us-east-1a", "us-east-1b"]
 
 # EC2
-# Amazon Linux 2023 (us-east-1) — update for other regions
-ami_id        = "ami-0c02fb55956c7d316"
+# ami_id is auto-resolved to the latest Amazon Linux 2023 (x86_64) AMI for
+# aws_region via the aws_ami data source in modules/ec2. Set it here only to
+# pin a specific AMI override.
+# ami_id      = "ami-xxxxxxxxxxxxxxxxx"
 instance_type = "t3.micro"
 
 # RDS

--- a/backend/devOps/terraform/environments/dev/variables.tf
+++ b/backend/devOps/terraform/environments/dev/variables.tf
@@ -36,8 +36,9 @@ variable "availability_zones" {
 }
 
 variable "ami_id" {
-  description = "AMI ID for EC2 instances (Amazon Linux 2023)"
+  description = "Optional AMI ID override for EC2 instances. Leave null to auto-resolve the latest Amazon Linux 2023 (x86_64) AMI for aws_region."
   type        = string
+  default     = null
 }
 
 variable "instance_type" {

--- a/backend/devOps/terraform/environments/prod/terraform.tfvars
+++ b/backend/devOps/terraform/environments/prod/terraform.tfvars
@@ -9,7 +9,10 @@ private_subnet_cidrs = ["10.2.10.0/24", "10.2.20.0/24"]
 availability_zones   = ["us-east-1a", "us-east-1b"]
 
 # ─── EC2 ──────────────────────────────────────────────────────────────────────
-ami_id        = "ami-0c02fb55956c7d316"
+# ami_id is auto-resolved to the latest Amazon Linux 2023 (x86_64) AMI for
+# aws_region via the aws_ami data source in modules/ec2. Set it here only to
+# pin a specific AMI override.
+# ami_id      = "ami-xxxxxxxxxxxxxxxxx"
 instance_type = "t3.medium"
 
 # ─── RDS ──────────────────────────────────────────────────────────────────────

--- a/backend/devOps/terraform/environments/prod/variables.tf
+++ b/backend/devOps/terraform/environments/prod/variables.tf
@@ -36,8 +36,9 @@ variable "availability_zones" {
 }
 
 variable "ami_id" {
-  description = "AMI ID for EC2 instances (Amazon Linux 2023)"
+  description = "Optional AMI ID override for EC2 instances. Leave null to auto-resolve the latest Amazon Linux 2023 (x86_64) AMI for aws_region."
   type        = string
+  default     = null
 }
 
 variable "instance_type" {

--- a/backend/devOps/terraform/environments/staging/terraform.tfvars
+++ b/backend/devOps/terraform/environments/staging/terraform.tfvars
@@ -9,7 +9,10 @@ private_subnet_cidrs = ["10.1.10.0/24", "10.1.20.0/24"]
 availability_zones   = ["us-east-1a", "us-east-1b"]
 
 # ─── EC2 ──────────────────────────────────────────────────────────────────────
-ami_id        = "ami-0c02fb55956c7d316"
+# ami_id is auto-resolved to the latest Amazon Linux 2023 (x86_64) AMI for
+# aws_region via the aws_ami data source in modules/ec2. Set it here only to
+# pin a specific AMI override.
+# ami_id      = "ami-xxxxxxxxxxxxxxxxx"
 instance_type = "t3.small"
 
 # ─── RDS ──────────────────────────────────────────────────────────────────────

--- a/backend/devOps/terraform/environments/staging/variables.tf
+++ b/backend/devOps/terraform/environments/staging/variables.tf
@@ -36,8 +36,9 @@ variable "availability_zones" {
 }
 
 variable "ami_id" {
-  description = "AMI ID for EC2 instances (Amazon Linux 2023)"
+  description = "Optional AMI ID override for EC2 instances. Leave null to auto-resolve the latest Amazon Linux 2023 (x86_64) AMI for aws_region."
   type        = string
+  default     = null
 }
 
 variable "instance_type" {

--- a/backend/devOps/terraform/modules/ec2/main.tf
+++ b/backend/devOps/terraform/modules/ec2/main.tf
@@ -14,10 +14,36 @@ locals {
 data "aws_caller_identity" "current" {}
 data "aws_elb_service_account" "main" {}
 
+# AMI LOOKUP — resolves the latest Amazon Linux 2023 (x86_64) AMI for the
+# provider's configured region. This keeps the AMI region-aware instead of
+# hardcoding a single us-east-1 id across every environment, and guarantees an
+# AL2023 image so the dnf-based user_data bootstrap succeeds.
+data "aws_ami" "al2023" {
+  most_recent = true
+  owners      = ["amazon"]
+
+  filter {
+    name   = "name"
+    values = ["al2023-ami-*-x86_64"]
+  }
+
+  filter {
+    name   = "architecture"
+    values = ["x86_64"]
+  }
+
+  filter {
+    name   = "virtualization-type"
+    values = ["hvm"]
+  }
+}
+
 # LAUNCH TEMPLATE
 resource "aws_launch_template" "app" {
-  name_prefix   = "${local.name_prefix}-lt-"
-  image_id      = var.ami_id
+  name_prefix = "${local.name_prefix}-lt-"
+  # Use the explicit override when provided, otherwise fall back to the
+  # region-aware AL2023 lookup above.
+  image_id      = coalesce(var.ami_id, data.aws_ami.al2023.id)
   instance_type = var.instance_type
   key_name      = var.key_name
 

--- a/backend/devOps/terraform/modules/ec2/variables.tf
+++ b/backend/devOps/terraform/modules/ec2/variables.tf
@@ -40,8 +40,9 @@ variable "instance_type" {
 }
 
 variable "ami_id" {
-  description = "AMI ID for EC2 instances (Amazon Linux 2023 recommended)"
+  description = "Optional AMI ID override for EC2 instances. Leave null to auto-resolve the latest Amazon Linux 2023 (x86_64) AMI for the configured region via the aws_ami data source."
   type        = string
+  default     = null
 }
 
 variable "key_name" {


### PR DESCRIPTION
## Summary

All three environment tfvars (dev, staging, prod) pinned the same hardcoded AMI `ami-0c02fb55956c7d316`, which is an **Amazon Linux 2** image in us-east-1. But `modules/ec2/user_data.sh.tpl` installs packages with `dnf`, which AL2 does not ship (AL2 uses `yum`). The bootstrap failed on the first `dnf` call, so instances never installed Node / the CloudWatch agent / the app and never passed the ALB health check. The dev tfvars comment also mislabeled the AL2 AMI as "Amazon Linux 2023".

This PR resolves the AMI through a region-aware Amazon Linux 2023 lookup instead of a single hardcoded id.

## How each acceptance criterion is met

- **Pin an AL2023 AMI via an `aws_ami` data source** — Added `data "aws_ami" "al2023"` in `modules/ec2/main.tf` with `owners = ["amazon"]`, `most_recent = true`, and filters `name = al2023-ami-*-x86_64`, `architecture = x86_64`, `virtualization-type = hvm`. The `x86_64` arch matches the module's `t3.*` instance types. `dnf` is retained in user_data, which is correct for AL2023.
- **Region-aware lookup instead of one hardcoded us-east-1 id** — The data source resolves against the AWS provider's configured region (driven by `var.aws_region` per environment), so each environment/region automatically gets the correct AL2023 AMI. No more hardcoded us-east-1 id shared across environments.
- **`var.ami_id` becomes an optional override** — In both the EC2 module and the three env `variables.tf`, `ami_id` now defaults to `null`. The launch template selects the image with `coalesce(var.ami_id, data.aws_ami.al2023.id)`: an explicit override is used when set, otherwise the data-source lookup wins.
- **Remove stale hardcoded `ami_id` from tfvars** — Removed from dev, staging and prod tfvars (left commented as an optional-override example).
- **Fix the misleading AL2023 comment in dev tfvars** — Replaced the `# Amazon Linux 2023 (us-east-1)` comment (which sat above an AL2 AMI) with an accurate note explaining the auto-resolution behavior.

## Out of scope

Container deploy and instance types were left untouched, per the issue.

## Verify

- `terraform`/`tofu` are not installed in this environment, so `terraform fmt`/`validate` could not be run. The HCL was hand-formatted to `terraform fmt` conventions (aligned `=`, 2-space indent, blank-line-separated blocks) and reviewed manually.
- `coalesce(var.ami_id, ...)` correctly skips the `null`/empty override and returns the data-source id when no override is provided.

Closes #105