### PR TITLE
fix(backend): set trust proxy so rate limiter keys on real client IP

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -3,9 +3,17 @@ import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import { swaggerSpec } from './config/swagger.js';
 import streamRoutes from './routes/stream.routes.js';
-import { globalRateLimiter } from './middleware/rate-limiter.middleware.js';
+import { globalRateLimiter, TRUSTED_PROXY_HOPS } from './middleware/rate-limiter.middleware.js';
 
 const app = express();
+
+// Trust the exact number of reverse proxies in front of the app
+// (AWS ALB -> nginx = 2 hops) so `req.ip` resolves to the real client IP.
+// This must run before the rate limiter so per-client limiting keys on the
+// real client instead of the proxy, and to avoid express-rate-limit's
+// ERR_ERL_UNEXPECTED_X_FORWARDED_FOR error. We trust a fixed hop count
+// rather than `true` to prevent X-Forwarded-For spoofing.
+app.set('trust proxy', TRUSTED_PROXY_HOPS);
 
 // Apply global rate limiter first
 app.use(globalRateLimiter);

--- a/backend/src/middleware/rate-limiter.middleware.ts
+++ b/backend/src/middleware/rate-limiter.middleware.ts
@@ -1,5 +1,18 @@
 import { rateLimit } from 'express-rate-limit';
 
+/**
+ * Number of reverse proxies in front of the Express app, used as the
+ * `trust proxy` setting so that `req.ip` (and therefore per-client rate
+ * limiting) resolves to the real client IP instead of a proxy address.
+ *
+ * Topology: client -> AWS Application Load Balancer -> nginx -> Express.
+ *   - The ALB appends the client IP to `X-Forwarded-For` (hop 1).
+ *   - nginx (devOps/nginx/nginx.conf) proxies to the backend (hop 2).
+ * That is 2 trusted hops. We intentionally avoid `trust proxy: true`,
+ * which would trust every upstream and let clients spoof `X-Forwarded-For`.
+ */
+export const TRUSTED_PROXY_HOPS = 2;
+
 export const globalRateLimiter = rateLimit({
   windowMs: 1 * 60 * 1000, // 1 minute
   max: 100, // Limit each IP to 100 requests per `window` (here, per minute)


### PR DESCRIPTION
## Summary

The Express backend mounts `globalRateLimiter` (express-rate-limit, `standardHeaders: true`) but never calls `app.set('trust proxy', ...)`. The service runs behind an AWS ALB and nginx, so `req.ip` resolved to the proxy address on every request. Consequences:

- All clients shared a single rate-limit bucket: one noisy client could lock everyone out (or the limit could be bypassed).
- express-rate-limit v8 raises `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR` because `X-Forwarded-For` is present without `trust proxy` configured.

This PR sets the correct `trust proxy` hop count before mounting the rate limiter.

## How each acceptance criterion is met

- **Set an appropriate `trust proxy` value before the rate limiter** — `app.set('trust proxy', TRUSTED_PROXY_HOPS)` is added in `backend/src/app.ts` immediately after `express()` and before `app.use(globalRateLimiter)`.
- **Verify the limiter keys on the real client IP** — confirmed at runtime (see Verify notes): with the real `globalRateLimiter` behind a simulated ALB+nginx chain, `req.ip` resolves to the real client and per-client buckets are isolated.
- **Avoid trusting all proxies blindly** — a fixed numeric hop count is used, not `true`. A comment explains this prevents `X-Forwarded-For` spoofing.
- **Document the chosen hop count** — `TRUSTED_PROXY_HOPS` is exported from `backend/src/middleware/rate-limiter.middleware.ts` with a JSDoc block describing the proxy topology, so the value lives next to the limiter it protects. `app.ts` imports it.

## Chosen hop count + justification

`TRUSTED_PROXY_HOPS = 2`.

Request path: **client -> AWS ALB -> nginx -> Express**.
- Terraform provisions an Application Load Balancer: `backend/devOps/terraform/modules/ec2/main.tf` (`aws_lb.app`, `load_balancer_type = "application"`). The ALB appends the client IP to `X-Forwarded-For` (hop 1).
- docker-compose runs nginx (`backend/devOps/docker/docker-compose.nginx.yml`); `backend/devOps/nginx/nginx.conf` does `proxy_pass` to the backend (hop 2).

That is exactly 2 trusted hops. Express's numeric `trust proxy = 2` treats the 2 closest addresses as trusted proxies and uses the next address as `req.ip` — the real client.

## Verify notes

Run in `backend/`:

- `npm install` fails on this dev machine for an unrelated, pre-existing reason: a transitive `@tailwindcss/oxide-linux-x64-gnu` is pinned to linux/x64 and rejects darwin/arm64 (`EBADPLATFORM`). Installed with `npm install --force` for local verification only; `package-lock.json` was not modified in this PR.
- `npx prisma generate` (required because the generated Prisma client is gitignored), then `npx tsc --noEmit` — passes with no errors.
- `npx vitest run tests/rate-limiter.test.ts` — 2 passed.
- Runtime check against the real `globalRateLimiter` with `trust proxy = 2` and a simulated `X-Forwarded-For: <client>, <alb-ip>`:
  - `req.ip` resolves to the real client IP.
  - Client A exhausts its own 100/min bucket (429) while a different client B is still served (200), proving per-client keying rather than a shared proxy bucket.

## Out of scope

- Redis-backed distributed rate limiting and per-route limits (explicitly out of scope per the issue).
- The `EBADPLATFORM` install failure is a pre-existing, environment-specific dependency issue unrelated to this change.

Closes #108