### PR TITLE
Fix/memoize event filter

### DIFF
--- a/frontend/hooks/useContractEvents.ts
+++ b/frontend/hooks/useContractEvents.ts
@@ -86,7 +86,7 @@ export function useStreamEvents(contractId: string, streamId: string | null) {
 
   const streamEvents = streamId
     ? events.filter(
-        (event) =>
+        (event: ContractEvent) =>
           event.data?.stream_id === streamId &&
           filter.eventTypes.includes(event.type)
       )

--- a/frontend/hooks/useContractEvents.ts
+++ b/frontend/hooks/useContractEvents.ts
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect, useCallback, useRef } from "react";
+import { useState, useEffect, useCallback, useRef, useMemo } from "react";
 import { useWallet } from "@/context/wallet-context";
 
 export interface ContractEvent {
@@ -73,18 +73,23 @@ export function useContractEvents(filter: EventFilter) {
   };
 }
 
-/**
- * Hook for listening to specific stream events
- * Filters events for a particular stream ID
- */
 export function useStreamEvents(contractId: string, streamId: string | null) {
-  const { events, isListening, error } = useContractEvents({
-    contractId,
-    eventTypes: ["stream_created", "tokens_withdrawn", "stream_cancelled", "stream_topped_up"],
-  });
+  const filter = useMemo(
+    () => ({
+      contractId,
+      eventTypes: ["stream_created", "tokens_withdrawn", "stream_cancelled", "stream_topped_up"],
+    }),
+    [contractId]
+  );
+
+  const { events, isListening, error } = useContractEvents(filter);
 
   const streamEvents = streamId
-    ? events.filter((event) => event.data?.stream_id === streamId)
+    ? events.filter(
+        (event) =>
+          event.data?.stream_id === streamId &&
+          filter.eventTypes.includes(event.type)
+      )
     : [];
 
   return {


### PR DESCRIPTION
closes #112 

Fixes the useContractEvents listener churn by memoizing the event filter and properly applying the eventTypes filter to stream processing.

Branch: fix/memoize-event-filter

Why this matters
Previously, useStreamEvents passed a brand-new object literal { contractId, eventTypes: [...] } to useContractEvents on every render. Because filter was in the dependency array of the setup useEffect, this caused the listener interval to be torn down and recreated continuously, churning timers and flooding logs. Additionally, the eventTypes array was passed in but completely ignored, meaning events weren't actually being filtered by type.

What was changed
Memoized the Filter: Wrapped the filter object in useStreamEvents with useMemo, keyed on contractId. This guarantees the object reference remains stable across renders, so the useEffect inside useContractEvents now sets up the listener exactly once per contract and cleans up cleanly on unmount.
Applied Event Filtering: Updated the events.filter(...) processing block inside useStreamEvents to verify that event.type exists in filter.eventTypes. The unused parameter is now properly evaluated when formatting the stream output.
Added useMemo Import: Added the missing React import to support the memoization.
Out of scope
Implementing the real Horizon/WebSocket event source (remains a TODO).
Wiring these events deeper into the UI components.
