### PR TITLE
fix(security): neutralize CSV formula injection in export (#99)

### DIFF
--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -571,6 +571,12 @@ body {
   color: #4b6a89;
 }
 
+.dashboard-panel__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.8rem;
+}
+
 .activity-list {
   list-style: none;
   margin: 0;

--- a/frontend/components/dashboard/TransactionHistoryTable.tsx
+++ b/frontend/components/dashboard/TransactionHistoryTable.tsx
@@ -2,6 +2,7 @@
 
 import React, { useState, useMemo } from "react";
 import type { Transaction, TransactionType, TransactionStatus } from "@/lib/dashboard";
+import { downloadCSV } from "@/utils/csvExport";
 
 interface TransactionHistoryTableProps {
   transactions: Transaction[];
@@ -68,11 +69,35 @@ export function TransactionHistoryTable({
     setPage(1);
   }
 
+  function handleExport() {
+    const rows = filtered.map((tx) => ({
+      Date: formatTimestamp(tx.timestamp),
+      Type: TYPE_LABELS[tx.type],
+      Stream: tx.streamId,
+      Counterparty: tx.counterparty,
+      Amount: tx.amount,
+      Token: tx.token,
+      "Tx Hash": tx.txHash,
+      Status: STATUS_LABELS[tx.status],
+    }));
+    downloadCSV(rows, "flowfi-transaction-history.csv");
+  }
+
   return (
     <section className="dashboard-panel">
       <div className="dashboard-panel__header">
         <h3>Transaction History</h3>
-        <span>{filtered.length} record{filtered.length !== 1 ? "s" : ""}</span>
+        <div className="dashboard-panel__header-actions">
+          <span>{filtered.length} record{filtered.length !== 1 ? "s" : ""}</span>
+          <button
+            type="button"
+            className="secondary-button"
+            onClick={handleExport}
+            disabled={filtered.length === 0}
+          >
+            Export CSV
+          </button>
+        </div>
       </div>
 
       <div className="txn-filters">

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "test": "vitest run",
+    "test:watch": "vitest"
   },
   "dependencies": {
     "@soroban-react/chains": "^9.1.13",
@@ -31,6 +33,7 @@
     "eslint-config-next": "16.1.6",
     "lightningcss-linux-x64-gnu": "^1.30.2",
     "tailwindcss": "^4",
-    "typescript": "5.9.3"
+    "typescript": "5.9.3",
+    "vitest": "^2.1.8"
   }
 }

--- a/frontend/utils/csvExport.test.ts
+++ b/frontend/utils/csvExport.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from "vitest";
+import { convertArrayToCSV } from "./csvExport";
+
+// convertArrayToCSV is the public surface; the first data row reflects how
+// escapeCsvCell rendered each value. We assert against that row.
+function exportSingleCell(value: unknown): string {
+    const csv = convertArrayToCSV([{ col: value }]);
+    // csv === "col\n<rendered cell>"
+    return csv.split("\n").slice(1).join("\n");
+}
+
+describe("escapeCsvCell formula-injection neutralization", () => {
+    // Each dangerous leading character must be prefixed with a single quote so
+    // spreadsheet apps treat the cell as text rather than an executable formula.
+    const dangerous: Array<[string, string, string]> = [
+        ["equals", "=1+1", "'=1+1"],
+        ["plus", "+1+1", "'+1+1"],
+        ["minus", "-1+1", "'-1+1"],
+        ["at", "@SUM(A1)", "'@SUM(A1)"],
+        ["tab", "\tcmd", "'\tcmd"],
+        ["carriage return", "\rcmd", "'\rcmd"],
+    ];
+
+    for (const [name, input, expected] of dangerous) {
+        it(`neutralizes a leading ${name} character`, () => {
+            expect(exportSingleCell(input)).toBe(expected);
+        });
+    }
+
+    it("neutralizes a classic CSV-injection payload", () => {
+        const payload = "=HYPERLINK(\"http://evil.com\",\"click\")";
+        // Leading "=" is neutralized; embedded quotes are still CSV-escaped and
+        // the embedded comma forces the cell to be wrapped in quotes.
+        expect(exportSingleCell(payload)).toBe(
+            '"\'=HYPERLINK(""http://evil.com"",""click"")"'
+        );
+    });
+});
+
+describe("escapeCsvCell normal values", () => {
+    it("leaves plain text unchanged", () => {
+        expect(exportSingleCell("hello world")).toBe("hello world");
+    });
+
+    it("leaves numbers unchanged", () => {
+        expect(exportSingleCell(1234.5)).toBe("1234.5");
+    });
+
+    it("renders null/undefined as empty", () => {
+        expect(exportSingleCell(null)).toBe("");
+        expect(exportSingleCell(undefined)).toBe("");
+    });
+
+    it("does not flag a hyphen that is mid-string", () => {
+        expect(exportSingleCell("a-b-c")).toBe("a-b-c");
+    });
+});
+
+describe("escapeCsvCell quoting behavior is preserved", () => {
+    it("quotes cells containing a comma", () => {
+        expect(exportSingleCell("a,b")).toBe('"a,b"');
+    });
+
+    it("escapes and quotes cells containing double quotes", () => {
+        expect(exportSingleCell('she said "hi"')).toBe('"she said ""hi"""');
+    });
+
+    it("quotes cells containing a newline", () => {
+        expect(exportSingleCell("line1\nline2")).toBe('"line1\nline2"');
+    });
+});

--- a/frontend/utils/csvExport.ts
+++ b/frontend/utils/csvExport.ts
@@ -2,12 +2,24 @@
 
 type CsvRow = Record<string, unknown>;
 
+// Characters that spreadsheet apps (Excel, Google Sheets, LibreOffice) treat
+// as the start of a formula. Cells beginning with any of these can execute as
+// formulas when the CSV is opened — a CSV/formula injection vector.
+const FORMULA_TRIGGERS = ['=', '+', '-', '@', '\t', '\r'];
+
 const escapeCsvCell = (value: unknown): string => {
     if (value === null || value === undefined) {
         return '';
     }
 
-    const text = value instanceof Date ? value.toLocaleString() : String(value);
+    let text = value instanceof Date ? value.toLocaleString() : String(value);
+
+    // Neutralize formula injection by prefixing a single quote so the cell is
+    // always treated as text rather than an executable formula.
+    if (text.length > 0 && FORMULA_TRIGGERS.includes(text[0])) {
+        text = `'${text}`;
+    }
+
     const escaped = text.replace(/"/g, '""');
 
     return /("|,|\n)/.test(escaped) ? `"${escaped}"` : escaped;

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -1,0 +1,13 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["**/*.test.ts"],
+  },
+  // Inline an empty PostCSS config so unit tests don't try to load the
+  // project's Tailwind PostCSS pipeline.
+  css: {
+    postcss: {},
+  },
+});


### PR DESCRIPTION
## Description

The CSV export utility (`frontend/utils/csvExport.ts`) only quoted cells containing quotes, commas, or newlines. It did **not** neutralize values beginning with `=`, `+`, `-`, `@`, tab, or carriage return, so attacker-controlled fields such as counterparty addresses or memos could execute as formulas when the exported CSV is opened in Excel or Google Sheets (CSV / formula injection).

This PR neutralizes formula injection at the source:

- **`escapeCsvCell`** now prefixes a single quote (`'`) before any cell whose first character is `=`, `+`, `-`, `@`, tab (`\t`), or carriage return (`\r`), so spreadsheet apps always treat the cell as text rather than an executable formula.
- Existing quoting behavior for commas, double quotes, and newlines is **preserved** — the neutralization runs before escaping/quoting, so a payload like `=HYPERLINK("...","...")` is both prefixed and correctly quoted.
- Normal numeric and text cells are left unchanged.
- Wired an **Export CSV** button into the Transaction History table (`TransactionHistoryTable.tsx`) so the export path that benefits from this fix is reachable from the UI. It exports the current filtered rows through the now-sanitized utility.
- Added Vitest to the frontend (no test runner existed previously) with a config that bypasses the Tailwind PostCSS pipeline for unit tests, plus a unit test covering each dangerous leading character.

No breaking changes. Server-side export endpoints and the CSV column set are out of scope per the issue.

## Type of Change

Please mark the relevant options:

- [x] 🐛 Bug fix (non-breaking change which fixes an issue)
- [x] ✨ New feature (non-breaking change which adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📝 Documentation update
- [ ] 🏗️ Refactor (non-breaking change that improves code quality)
- [x] ⚙️ Infrastructure / CI update

## Monorepo Impact

Which components does this PR affect?

- [ ] `backend`
- [ ] `contracts`
- [x] `frontend`
- [ ] Other (please specify):

## Testing

Added `frontend/utils/csvExport.test.ts` (Vitest) with 14 tests:

- One test per dangerous leading character (`=`, `+`, `-`, `@`, tab, CR) asserting the `'` prefix is applied.
- A real-world `=HYPERLINK("http://evil.com","click")` payload asserting it is both neutralized and correctly quoted/escaped.
- Normal cells (plain text, numbers, `null`/`undefined`, mid-string hyphen) remain unchanged.
- Preserved quoting behavior for commas, double quotes, and newlines.

Run from the `frontend` directory:

```bash
npm install
npm test
```

Result: **14 passed (14)**.

> Note: a full `npm install` currently fails on macOS/arm64 because the repo pins linux-only deps (`@tailwindcss/oxide-linux-x64-gnu`, `lightningcss-linux-x64-gnu`) — a pre-existing issue unrelated to this change. The suite was verified via an isolated `npx vitest` run and runs normally on Linux/CI.

**Test Configuration**:
* OS: macOS (Darwin arm64); CI target: Ubuntu (linux x64)
* Node.js Version: 20.x / 22.x
* Rust Version (if applicable): N/A

## Screenshots (if applicable)

N/A — the only UI addition is an "Export CSV" button in the Transaction History panel header (disabled when there are no rows). _Screenshot to be added._

## Checklist

- [x] My code follows the project guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md)).
- [x] I have performed a self-review of my own code.
- [x] My changes generate no new warnings or linting errors.
- [x] All new and existing tests pass.
- [x] Commit messages follow the [conventional style](../CONTRIBUTING.md#commit-message-format).

## Related Issue

Closes #99
