### PR TITLE
docs: eliminate duplicate variables and fix CI/CD documentation (#113)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,12 +1,19 @@
-# Server
+# ==============================================================================
+# Server Configuration
+# ==============================================================================
 PORT=3001
-NODE_ENV=development
+NODE_ENV=development          # development | production
+LOG_LEVEL=info                # error | warn | info | debug
 
+# ==============================================================================
 # Stellar Network (Testnet/Mainnet)
+# ==============================================================================
 STELLAR_NETWORK=testnet
 STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
 
+# ==============================================================================
 # PostgreSQL (docker-compose postgres service)
+# ==============================================================================
 POSTGRES_USER=your_db_user
 POSTGRES_PASSWORD=your_db_password
 POSTGRES_DB=liquidflow
@@ -14,17 +21,9 @@ POSTGRES_DB=liquidflow
 # Backend – Prisma / app
 DATABASE_URL=postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
 
-NODE_ENV=development          # development | production
-PORT=3001
-LOG_LEVEL=info                # error | warn | info | debug
-
-# GitHub Actions: enable/disable continuous deployment
-# Set to `true` to allow the CD workflow to proceed when pushing to `main`.
-# This variable is read by `.github/workflows/cd.yml`'s `check-flag` job.
-ENABLE_CD=true               # true | false
-
-
-# AWS – authentication (pick ONE method)
+# ==============================================================================
+# AWS – Authentication (Pick ONE method)
+# ==============================================================================
 # Option A: named profile (recommended for local dev)
 AWS_PROFILE=your-aws-profile
 
@@ -34,10 +33,25 @@ AWS_PROFILE=your-aws-profile
 
 AWS_REGION=us-east-1
 
-# Terraform – scripts & sensitive input variables
+# ==============================================================================
+# Terraform – Scripts & Sensitive Input Variables
+# ==============================================================================
 PROJECT_NAME=liquidflow          # used by bootstrap.sh
 TF_LOG=INFO                      # TRACE | DEBUG | INFO | WARN | ERROR | OFF
 
 # Sensitive Terraform input variables (TF_VAR_* prefix)
 # These override values in terraform.tfvars without committing secrets
 TF_VAR_db_username=your_db_admin_user
+
+# ==============================================================================
+# CI/CD NOTE (GitHub Actions Configuration)
+# ==============================================================================
+# NOTE: The continuous deployment flag (ENABLE_CD) is NOT an application-level 
+# environment variable and should not be set here.
+#
+# To control your deployment workflows, define it as a GitHub Repository Variable:
+# Go to: Repository Settings -> Secrets and Variables -> Variables
+# Variable name: ENABLE_CD
+# Value: true | false
+#
+# The workflow at `devOps/.github/workflows/aws/cd.yml` reads this via `${{ vars.ENABLE_CD }}`.

--- a/backend/devOps/.github/workflows/aws/cd.yml
+++ b/backend/devOps/.github/workflows/aws/cd.yml
@@ -105,16 +105,16 @@ jobs:
             # ── Pull new image ────────
             docker pull ${{ secrets.DOCKER_HUB_USER }}/liquidflow-backend:${{ needs.build.outputs.image_tag }}
 
-            # ── Restart services ────────────
+            # ── Restart services (FIXED PATHS HERE) ────────────
             docker compose \
-              -f devOps/docker/docker-compose.yml \
-              -f devOps/docker/docker-compose.prod.yml \
+              -f backend/devOps/docker/docker-compose.yml \
+              -f backend/devOps/docker/docker-compose.prod.yml \
               --env-file .env \
               up -d --remove-orphans
 
-            # ── Prisma migrations ─────────────
+            # ── Prisma migrations (FIXED PATHS HERE) ─────────────
             docker compose \
-              -f devOps/docker/docker-compose.yml \
+              -f backend/devOps/docker/docker-compose.yml \
               --env-file .env \
               exec -T backend npx prisma migrate deploy
 


### PR DESCRIPTION
#closes #113 
🚀 PR Title: docs/fix: clean up .env.example duplicates and correct CD workflow paths (#113)
📝 Description
This PR addresses Issue #113 by restructuring the backend environment example configuration and correcting invalid relative paths inside the continuous deployment workflow.

It eliminates misleading environment flags that belong on the repository management layer rather than the application level, deduplicates overlapping keys, and repairs runtime deployment errors.

🛠️ Key Changes MatrixModuleFile PathDescriptionBackend (Docs)backend/.env.exampleRemoved duplicate NODE_ENV and PORT declarations. Removed ENABLE_CD from local environment variables and documented its correct placement as a GitHub Repository Variable.DevOps (CI/CD)backend/devOps/.github/workflows/aws/cd.ymlFixed docker compose configuration relative paths by appending the missing backend/ directory prefix to match the monorepo architecture.

🔒 Details of Fixes
1. Configuration Sanitization (backend/.env.example)
Deduplication: Cleaned up redundant multi-line declarations of NODE_ENV=development and PORT=3001 which were causing configuration pollution.

Separation of Concerns: Removed ENABLE_CD=true. Because the continuous deployment workflow file checks this flag using the custom GitHub context ${{ vars.ENABLE_CD }}, defining it locally in a runtime .env file does nothing. Replaced it with comprehensive code documentation guiding future engineers to the repo settings dashboard.

2. Path Repair (cd.yml)
While checking the workflow logic, a severe relative file path error was discovered. The script executes from the repository context root (~/liquidflow), but the target infrastructure files are nested deeper down inside the workspace directory structure (backend/devOps/docker/...).

Updated the path arrays on lines executing the production composition configuration and Prisma schema deployment steps to include the correct relative directory mapping.

🧪 How to Test Locally & Validate
1. File Inspection
Verify that backend/.env.example contains only one copy of NODE_ENV and PORT, and displays the informative commentary section regarding ENABLE_CD.

2. Validate GitHub Action Workflow Schema
You can check that the updated cd.yml maintains strict YAML formatting integrity by using a syntax linter or the GitHub Actions dry-run interface:

Bash
# Verify file exists where the runner expects it
ls backend/devOps/.github/workflows/aws/cd.yml

🏁 Checklist
[x] Redundant environment keys removed.

[x] CI/CD operational flags correctly designated to the repository variables scope.

[x] Monorepo path structures explicitly linked across SSH deploy actions.

[x] Code modifications contain zero leaked secrets or production parameters.
#closes 