### PR TITLE
fix: remove broken catch-all middleware that hangs GET / and /health

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -36,16 +36,6 @@ app.get('/api-docs.json', (req: Request, res: Response) => {
 // Routes
 app.use('/streams', streamRoutes);
 
-// Health check endpoints
-app.use((req: Request, res: Response, next) => {
-    return {
-        status: 'healthy',
-        timestamp: new Date().toISOString(),
-        uptime: process.uptime(),
-        version: '1.0.0',
-    }
-});
-
 /**
  * @openapi
  * /:

--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import request from 'supertest';
+import app from '../src/app.js';
+
+describe('Health check endpoints', () => {
+  it('GET / returns 200 with running message', async () => {
+    const response = await request(app).get('/');
+
+    expect(response.status).toBe(200);
+    expect(response.text).toBe('FlowFi Backend is running');
+  });
+
+  it('GET /health returns 200 with health payload', async () => {
+    const response = await request(app).get('/health');
+
+    expect(response.status).toBe(200);
+    expect(response.body.status).toBe('healthy');
+    expect(response.body.timestamp).toBeDefined();
+    expect(typeof response.body.uptime).toBe('number');
+    expect(response.body.version).toBe('1.0.0');
+  });
+});


### PR DESCRIPTION
## Summary

- Removed the broken catch-all middleware in `backend/src/app.ts` (lines 40–47) that used `app.use()` with a handler returning a plain object instead of calling `next()` or sending a response — this caused every request not matched by `/streams` to stall indefinitely, making the documented `GET /` and `GET /health` endpoints unreachable.
- Added `backend/tests/health.test.ts` with tests asserting both endpoints respond with 200 and the expected payloads.

## Test plan

- [x] `GET /` returns 200 with `"FlowFi Backend is running"`
- [x] `GET /health` returns 200 with JSON health payload (`status`, `timestamp`, `uptime`, `version`)
- [x] All existing tests continue to pass (7/7 green)
- [x] `npx vitest run` passes locally

Closes #98