### PR TITLE
docs: update backend branding to LiquidFlow

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -30,7 +30,7 @@ app.use(
   swaggerUi.serve,
   swaggerUi.setup(swaggerSpec, {
     customCss: ".swagger-ui .topbar { display: none }",
-    customSiteTitle: "FlowFi API Documentation",
+    customSiteTitle: "LiquidFlow API Documentation",
   }),
 );
 
@@ -58,10 +58,10 @@ app.use('/streams', streamRoutes);
  *           text/plain:
  *             schema:
  *               type: string
- *               example: FlowFi Backend is running
+ *               example: LiquidFlow Backend is running
  */
 app.get("/", (req: Request, res: Response) => {
-  res.send("FlowFi Backend is running");
+  res.send("LiquidFlow Backend is running");
 });
 
 /**

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -4,16 +4,16 @@ const options: swaggerJsdoc.Options = {
   definition: {
     openapi: '3.0.0',
     info: {
-      title: 'FlowFi API',
+      title: 'LiquidFlow API',
       version: '1.0.0',
-      description: 'API documentation for FlowFi - Real-time payment streaming on Stellar',
+      description: 'API documentation for LiquidFlow - Real-time payment streaming on Stellar',
       contact: {
-        name: 'FlowFi Team',
-        url: 'https://github.com/LabsCrypt/flowfi',
+        name: 'LiquidFlow Team',
+        url: 'https://github.com/Flux-DeFi/LiquidFlow',
       },
       license: {
         name: 'MIT',
-        url: 'https://opensource.org/licenses/MIT',
+        url: 'https://github.com/Flux-DeFi/LiquidFlow/blob/main/LICENSE',
       },
     },
     servers: [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "flowfi",
+  "name": "liquidflow",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "flowfi",
+      "name": "liquidflow",
       "version": "1.0.0",
       "workspaces": [
         "frontend",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "flowfi",
+  "name": "liquidflow",
   "version": "1.0.0",
   "description": "DeFi Payment Streaming on Stellar",
   "private": true,


### PR DESCRIPTION
## Summary
- update Swagger UI/site metadata from FlowFi to LiquidFlow
- point Swagger contact and license URLs at Flux-DeFi/LiquidFlow
- rename the root package metadata to liquidflow and keep package-lock in sync

## Verification
- `rg -n "FlowFi|LabsCrypt/flowfi" backend/src package.json package-lock.json || true` returns no matches
- `git diff --check` passes
- `npm run build --workspace=backend` could not complete before this change because dependencies are not installed
- `npm install --ignore-scripts` and `npm install --ignore-scripts --workspace=backend` are blocked on macOS by `@tailwindcss/oxide-linux-x64-gnu` requiring linux/x64; I left the production API domain unchanged because the issue marks domain renaming out of scope

Closes #102