### PR TITLE
fix: resolve parameter shadowing and remove unused variables in stream_contract

### DIFF
--- a/contracts/stream_contract/src/lib.rs
+++ b/contracts/stream_contract/src/lib.rs
@@ -145,15 +145,12 @@ impl StreamContract {
 
     pub fn withdraw(env: Env, recipient: Address, stream_id: u64) {
         // Placeholder for withdraw logic
-        let _amount: i128 = 0;
-        let _timestamp = env.ledger().timestamp();
-        let _ = (recipient, stream_id);
+        let _ = (env, recipient, stream_id);
     }
 
     pub fn cancel_stream(env: Env, sender: Address, stream_id: u64) {
         sender.require_auth();
         // Placeholder for cancel logic
-        let _amount_withdrawn: i128 = 0;
         let _ = (env, stream_id);
     }
 

--- a/contracts/stream_contract/src/test.rs
+++ b/contracts/stream_contract/src/test.rs
@@ -34,15 +34,15 @@ fn test_create_stream() {
 
     assert_eq!(stream_id, 1);
 
-    let stream = client.get_stream(&stream_id);
-    assert!(stream.is_some());
-    let stream = stream.unwrap();
-    assert_eq!(stream.sender, sender);
-    assert_eq!(stream.recipient, recipient);
-    assert_eq!(stream.rate_per_second, amount / duration as i128);
-    assert_eq!(stream.token_address, token_address);
-    assert_eq!(stream.deposited_amount, amount);
-    assert_eq!(stream.withdrawn_amount, 0);
+    let stream_opt = client.get_stream(&stream_id);
+    assert!(stream_opt.is_some());
+    let stream_data = stream_opt.unwrap();
+    assert_eq!(stream_data.sender, sender);
+    assert_eq!(stream_data.recipient, recipient);
+    assert_eq!(stream_data.rate_per_second, amount / duration as i128);
+    assert_eq!(stream_data.token_address, token_address);
+    assert_eq!(stream_data.deposited_amount, amount);
+    assert_eq!(stream_data.withdrawn_amount, 0);
 }
 
 #[test]


### PR DESCRIPTION
Closes #96

**Summary:**
Resolved the compilation issues in the stream_contract by fixing parameter shadowing and unused variables. 

**What changed:**
- Renamed the shadowed `stream` variable to `stream_opt` and `stream_data` in the test file.
- Removed unused `_amount` and `_amount_withdrawn` placeholder variables in the `withdraw` and `cancel_stream` functions to avoid compiler warnings/errors.
- Addressed variable definitions to ensure the contract builds without issues.

**Verification:**
Checked the stream_contract code directly. Variables are correctly bound and parameter shadowing has been resolved.