### PR TITLE
docs: update backend branding to LiquidFlow and correct Swagger repository URL

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -30,7 +30,7 @@ app.use(
   swaggerUi.serve,
   swaggerUi.setup(swaggerSpec, {
     customCss: ".swagger-ui .topbar { display: none }",
-    customSiteTitle: "FlowFi API Documentation",
+    customSiteTitle: "LiquidFlow API Documentation",
   }),
 );
 
@@ -58,10 +58,10 @@ app.use('/streams', streamRoutes);
  *           text/plain:
  *             schema:
  *               type: string
- *               example: FlowFi Backend is running
+ *               example: LiquidFlow Backend is running
  */
 app.get("/", (req: Request, res: Response) => {
-  res.send("FlowFi Backend is running");
+  res.send("LiquidFlow Backend is running");
 });
 
 /**

--- a/backend/src/config/swagger.ts
+++ b/backend/src/config/swagger.ts
@@ -4,12 +4,12 @@ const options: swaggerJsdoc.Options = {
   definition: {
     openapi: '3.0.0',
     info: {
-      title: 'FlowFi API',
+      title: 'LiquidFlow API',
       version: '1.0.0',
-      description: 'API documentation for FlowFi - Real-time payment streaming on Stellar',
+      description: 'API documentation for LiquidFlow - Real-time payment streaming on Stellar',
       contact: {
-        name: 'FlowFi Team',
-        url: 'https://github.com/LabsCrypt/flowfi',
+        name: 'LiquidFlow Team',
+        url: 'https://github.com/Flux-DeFi/LiquidFlow',
       },
       license: {
         name: 'MIT',

--- a/backend/tests/health.test.ts
+++ b/backend/tests/health.test.ts
@@ -7,7 +7,7 @@ describe('Health check endpoints', () => {
     const response = await request(app).get('/');
 
     expect(response.status).toBe(200);
-    expect(response.text).toBe('FlowFi Backend is running');
+    expect(response.text).toBe('LiquidFlow Backend is running');
   });
 
   it('GET /health returns 200 with health payload', async () => {


### PR DESCRIPTION
Closes #102

**Summary:**
Updated backend references from FlowFi to LiquidFlow to ensure consistent branding and corrected the Swagger documentation contact URL to point to the current repository.

**What changed:**
- Replaced FlowFi mentions with LiquidFlow in the Swagger configuration file (`src/config/swagger.ts`).
- Updated the Swagger UI title and root endpoint string in `app.ts`.
- Updated the root health-check endpoint tests in `health.test.ts` to expect the new string.
- Directed the Swagger contact URL to `https://github.com/Flux-DeFi/LiquidFlow`.

**Verification:**
Reviewed the updated files and confirmed all `FlowFi` instances in the backend root code were swapped accurately.